### PR TITLE
Add cardinality logic, spot price and mutable fees

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,3 @@
 BaseTest:testGetQuoteNoPool() (gas: 12835)
-BaseTest:testGetUpdatedPool() (gas: 92736)
+BaseTest:testGetUpdatedPool() (gas: 90630)
 BaseTest:testUpdatePool() (gas: 68909)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,3 @@
-BaseTest:testGetQuoteNoPool() (gas: 12729)
-BaseTest:testUpdatePool() (gas: 63727)
+BaseTest:testGetQuoteNoPool() (gas: 12835)
+BaseTest:testGetUpdatedPool() (gas: 92736)
+BaseTest:testUpdatePool() (gas: 68909)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This design choice provides the following benefits:
 
 1. Users can update pools and increase their cardinality more or less frequently, depending on their needs;
 2. Users improve reliability of Uniswap V3 pools by increasing their cardinality as they interact with them;
-3. The more the price feed is used, the higher its reliability and usefulness for the Ethereum ecosystem.
+3. The more the price feed is used, the higher its efficiency, reliability and usefulness for the Ethereum ecosystem.
 
 At the same time anyone can use `getPool` to retrieve the current main pool for a currency pair, or `getQuote` to get a **time-weighted quote** by specifying the `currency addresses`, `the amount of base currency to convert` and the desired `twap interval`.
 
@@ -54,11 +54,11 @@ See the specifics in the [PriceFeed](contracts/PriceFeed.sol) contract.
 
 ## Deployments
 
-`PriceFeed` has been deployed to `0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71` on the following networks:
+`PriceFeed` has been deployed to `0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F` on the following networks:
 
-<!-- - [Ethereum Mainnet](https://etherscan.io/address/0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71) -->
+<!-- - [Ethereum Mainnet](https://etherscan.io/address/0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F) -->
 
-- [Ethereum Goerli Testnet](https://goerli.etherscan.io/address/0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71)
+- [Ethereum Goerli Testnet](https://goerli.etherscan.io/address/0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F)
 
 ## Support the project
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,18 @@ See the specifics in the [PriceFeed](contracts/PriceFeed.sol) contract.
 
 `PriceFeed` has been deployed to `0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F` on the following networks:
 
-<!-- - [Ethereum Mainnet](https://etherscan.io/address/0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F) -->
-
+- [Ethereum Mainnet](https://etherscan.io/address/0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F)
 - [Ethereum Goerli Testnet](https://goerli.etherscan.io/address/0xf2E8176c0b67232b20205f4dfbCeC3e74bca471F)
 
 ## Support the project
 
-You can support the project by donating to either its slicer or Juicebox treasury.
+You can support the project by donating to its slicer or Juicebox treasury.
 
 ### [Slicer](https://slice.so/slicer/22)
 
-By sending ETH to the slicer address `0x83c36BED51b6de81986390b6e64aDa045694E857` you're supporting the contributors of the project. You&apos;ll appear as sponsor in the slicer page and eventually receive rewards over time made by the development team.
+By sending ETH to the slicer address `0x83c36BED51b6de81986390b6e64aDa045694E857` you're supporting the contributors of the project. Doing so will allow you to appear as sponsor in the slicer page.
 
-In fact, **ownership over the slicer is distributed to the contributors of this repository, proportionally to their contributions**. You can check the ownership distribution in the [slicer page](https://slice.so/slicer/22?view=owners), or the specifics of each slice mint on each merged PR.
+> **Ownership over the slicer is split between the project's contributors**. You can check the ownership distribution in the [slicer page](https://slice.so/slicer/22?view=owners), or the specifics of past slice distributions on each merged PR.
 
 ### [Juicebox Treasury](https://juicebox.money/v2/p/264)
 
@@ -78,10 +77,6 @@ Funds sent to the [Juicebox treasury](https://juicebox.money/v2/p/264) are forwa
 
 This project uses [Foundry](https://github.com/foundry-rs/foundry) as development framework.
 
-### Merge-to-earn
+### Merge to earn
 
-When a PR is merged, **contributors receive slices granting them a part of the ownership and earnings related to the project**.
-
-Discussion on the slices to be issued can happen on Github or elsewhere. Once the PR is merged, the agreed amount of slices is minted to all contributors involved by the [gnosis safe](https://etherscan.io/address/0x71e1c244eF17516bcD1FA65db74F8F4f397e9097) (owned by maintainers).
-
-Learn how Slice works on the [website](https://slice.so) or ask questions on [Discord](https://discord.gg/c7puDHjgMU).
+This project uses [Merge to earn](https://github.com/slice-so/merge-to-earn) to reward contributors with a piece of the [Price feed slicer](https://slice.so/slicer/22) and its earnings, when pull requests are merged.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ Over sufficiently large time intervals, **harmonic mean liquidity (TWAL) can be 
 
 > You can learn more about TWAL and Liquidity Oracles in the [Uniswap V3 Core whitepaper](https://uniswap.org/whitepaper-v3.pdf).
 
-The price feed relies on the collaborative effort of users to keep updated the reference for the main pool for each currency pair. This is facilitated by `getUpdatedPool` and `getQuoteAndUpdatePool` which allow interacting with the feed while updating stale pools at the same time.
+The price feed relies on the collaborative effort of users to keep updated the reference for the main pool for each currency pair. This is facilitated by `getUpdatedPool` and `getQuoteAndUpdatePool` which allow interacting with the feed while updating stale pools and increasing observation cardinality at the same time.
 
-At the same time anyone can use `getPool` to retrieve the current main pool for a currency pair, or `getQuote` to get a time-weighted quote by specifying the `currency addresses`, `the amount of base currency to convert` and the `twap interval`.
+This design choice provides the following benefits:
+
+1. Users can update pools and increase their cardinality more or less frequently, depending on their needs;
+2. Users improve reliability of Uniswap V3 pools by increasing their cardinality as they interact with them;
+3. The more the price feed is used, the higher its reliability and usefulness for the Ethereum ecosystem.
+
+At the same time anyone can use `getPool` to retrieve the current main pool for a currency pair, or `getQuote` to get a **time-weighted quote** by specifying the `currency addresses`, `the amount of base currency to convert` and the desired `twap interval`.
 
 This makes it easy and efficient to interact with TWAP oracles or integrate them into other smart contracts.
 
-> The price feed will soon be used by the [Slice protocol](https://slice.so) to provide dynamic pricing for products in any ERC20 currency, periodically updating the pools it interacts with. Usage from more parties is encouraged to increase the usefulness and efficiency of the price feed for the whole Ethereum ecosystem.
+> The price feed will soon be used by the [Slice protocol](https://slice.so) to provide dynamic pricing for products in any ERC20 currency, periodically updating the pools it interacts with.
 
 ## Functions
 
@@ -48,20 +54,21 @@ See the specifics in the [PriceFeed](contracts/PriceFeed.sol) contract.
 
 ## Deployments
 
-`PriceFeed` has been deployed to `0xa706E21E91218E8F83B49C02B26a1cEdC153E586` on the following networks:
+`PriceFeed` has been deployed to `0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71` on the following networks:
 
-- [Ethereum Mainnet](https://etherscan.io/address/0xa706E21E91218E8F83B49C02B26a1cEdC153E586)
-- [Ethereum Goerli Testnet](https://goerli.etherscan.io/address/0xa706E21E91218E8F83B49C02B26a1cEdC153E586)
+<!-- - [Ethereum Mainnet](https://etherscan.io/address/0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71) -->
+
+- [Ethereum Goerli Testnet](https://goerli.etherscan.io/address/0x8a834e6bB36B8D5CF9294467F9b7070383f1ab71)
 
 ## Support the project
 
 You can support the project by donating to either its slicer or Juicebox treasury.
 
-### [Price Feed Slicer](https://slice.so/slicer/22)
+### [Slicer](https://slice.so/slicer/22)
 
-By sending ETH to the slicer address `0x83c36BED51b6de81986390b6e64aDa045694E857` you're supporting the contributors of the project. In addition, you&apos;ll appear as sponsor in the slicer page and potentially receive other rewards over time.
+By sending ETH to the slicer address `0x83c36BED51b6de81986390b6e64aDa045694E857` you're supporting the contributors of the project. You&apos;ll appear as sponsor in the slicer page and eventually receive rewards over time made by the development team.
 
-In fact **ownership over the slicer is distributed to the contributors of this repository, proportionally to their contributions**. You can check the ownership distribution in the [slicer page](https://slice.so/slicer/22?view=owners), or the specifics of each slice mint on each merged PR.
+In fact, **ownership over the slicer is distributed to the contributors of this repository, proportionally to their contributions**. You can check the ownership distribution in the [slicer page](https://slice.so/slicer/22?view=owners), or the specifics of each slice mint on each merged PR.
 
 ### [Juicebox Treasury](https://juicebox.money/v2/p/264)
 
@@ -71,9 +78,9 @@ Funds sent to the [Juicebox treasury](https://juicebox.money/v2/p/264) are forwa
 
 This project uses [Foundry](https://github.com/foundry-rs/foundry) as development framework.
 
-### Merge-to-own
+### Merge-to-earn
 
-When a PR is merged, **contributors receive slices granting them a part of the future donations / earnings of the project**.
+When a PR is merged, **contributors receive slices granting them a part of the ownership and earnings related to the project**.
 
 Discussion on the slices to be issued can happen on Github or elsewhere. Once the PR is merged, the agreed amount of slices is minted to all contributors involved by the [gnosis safe](https://etherscan.io/address/0x71e1c244eF17516bcD1FA65db74F8F4f397e9097) (owned by maintainers).
 

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -36,6 +36,8 @@ contract PriceFeed is IPriceFeed {
   uint16 public MAX_CARDINALITY = 256;
   /// UniswapV3Pool fee tiers
   uint24[] public fees = [10000, 3000, 500, 100];
+  /// Mapping of active fee tiers
+  mapping(uint24 => bool) public activeFees;
   /// UniswapV3Factory contract address
   address public immutable uniswapV3Factory;
 
@@ -52,6 +54,14 @@ contract PriceFeed is IPriceFeed {
 
   constructor(address uniswapV3Factory_) {
     uniswapV3Factory = uniswapV3Factory_;
+
+    // Activate fee tiers
+    for (uint256 i; i < fees.length; ) {
+      activeFees[fees[i]] = true;
+      unchecked {
+        ++i;
+      }
+    }
   }
 
   /// =================================
@@ -263,7 +273,8 @@ contract PriceFeed is IPriceFeed {
    * @param fee tier to add
    */
   function addFee(uint24 fee) public {
-    if (IUniswapV3Factory(uniswapV3Factory).feeAmountTickSpacing(fee) != 0) {
+    if (IUniswapV3Factory(uniswapV3Factory).feeAmountTickSpacing(fee) != 0 && !activeFees[fee]) {
+      activeFees[fee] = true;
       fees.push(fee);
     }
   }

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -209,7 +209,7 @@ contract PriceFeed is IPriceFeed {
         int24 arithmeticMeanTick;
 
         // If `getUpdatedPool` returned non null tickCumulatives
-        if (tickCumulatives[0] != tickCumulatives[1]) {
+        if (tickCumulatives.length != 0) {
           // Calculate arithmeticMeanTick from tickCumulatives
           int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
           arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsTwapInterval)));

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -32,8 +32,7 @@ contract PriceFeed is IPriceFeed {
   uint192 private constant UPDATE_INTERVAL_X160 = uint192(UPDATE_INTERVAL) << 160;
   /// UPDATE_INTERVAL formatted to secondsAgo array
   uint32[] private UPDATE_SECONDS_AGO = [UPDATE_INTERVAL, 0];
-  /// Value under which cardinality increase is triggered when updating pools via `getUpdatedPool`
-  /// or `getQuoteAndUpdatePool`
+  /// Current observation cardinality value under which a cardinality increase is triggered when updating pools
   uint16 public MAX_CARDINALITY = 256;
   /// UniswapV3Pool fee tiers
   uint24[] public fees = [10000, 3000, 500, 100];

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -30,7 +30,7 @@ contract PriceFeed is IPriceFeed {
   uint32 public constant UPDATE_INTERVAL = 30 minutes;
   /// UPDATE_INTERVAL multiplied by 2**160
   uint192 private constant UPDATE_INTERVAL_X160 = uint192(UPDATE_INTERVAL) << 160;
-  /// UPDATE_INTERVAL formatted to secondsAgo array
+  /// UPDATE_INTERVAL formatted as uint32[]
   uint32[] private UPDATE_SECONDS_AGO = [UPDATE_INTERVAL, 0];
   /// Current observation cardinality value under which a cardinality increase is triggered when updating pools
   uint16 public MAX_CARDINALITY = 256;
@@ -82,11 +82,11 @@ contract PriceFeed is IPriceFeed {
 
   /**
    * @notice Get the time-weighted quote of `quoteToken` received in exchange for a `baseAmount`
-   * of `baseToken`, from the pool with highest liquidity, based on a `secondsAgo` twap interval.
+   * of `baseToken`, from the pool with highest liquidity, based on a `secondsTwapInterval` twap interval.
    * @param baseAmount Amount of baseToken to be converted
    * @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
    * @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
-   * @param secondsAgo Number of seconds in the past from which to calculate the time-weighted quote
+   * @param secondsTwapInterval Number of seconds in the past from which to calculate the time-weighted quote
    * @return quoteAmount Equivalent amount of ERC20 token for baseAmount
    *
    * Note: If a pool does not exist or a valid quote is not returned execution will not revert and
@@ -96,20 +96,20 @@ contract PriceFeed is IPriceFeed {
     uint128 baseAmount,
     address baseToken,
     address quoteToken,
-    uint32 secondsAgo
+    uint32 secondsTwapInterval
   ) public view returns (uint256 quoteAmount) {
     address pool = getPool(baseToken, quoteToken).poolAddress;
 
     if (pool != address(0)) {
       // Get spot price
-      if (secondsAgo == 0) {
+      if (secondsTwapInterval == 0) {
         // Get sqrtPriceX96 from slot0
         (uint160 sqrtPriceX96, , , , , , ) = IUniswapV3Pool(pool).slot0();
         quoteAmount = _getQuoteAtSqrtPriceX96(sqrtPriceX96, baseAmount, baseToken, quoteToken);
       }
       // Get TWAP price
       else {
-        int24 arithmeticMeanTick = _getArithmeticMeanTick(pool, secondsAgo);
+        int24 arithmeticMeanTick = _getArithmeticMeanTick(pool, secondsTwapInterval);
         quoteAmount = OracleLibrary.getQuoteAtTick(
           arithmeticMeanTick,
           baseAmount,
@@ -124,22 +124,22 @@ contract PriceFeed is IPriceFeed {
    * @notice Retrieves stored pool given tokenA and tokenB regardless of order, and updates pool if necessary.
    * @param tokenA Address of one of the ERC20 token contract in the pool
    * @param tokenB Address of the other ERC20 token contract in the pool
-   * @param updateInterval Seconds after which a pool is considered stale and an update is triggered
-   * @param cardinalityIncrease The amount of cardinality to increase when updating a pool, if
+   * @param secondsUpdateInterval Seconds after which a pool is considered stale and an update is triggered
+   * @param cardinalityNextIncrease The amount of cardinality to increase when updating a pool, if
    * current value < MAX_CARDINALITY.
    * @return pool address, fee, last edit timestamp and last recorded cardinality.
    * @return tickCumulatives Cumulative tick values as of 30 minutes from the current block timestamp
    * @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
    *
-   * Note: Set updateInterval to 0 to always trigger an update, or to block.timestamp to only update if a pool
+   * Note: Set `secondsUpdateInterval` to 0 to always trigger an update, or to block.timestamp to only update if a pool
    * has not been stored yet.
-   * Note: Set `cardinalityIncrease` to 0 to disable increasing cardinality when updating pool.
+   * Note: Set `cardinalityNextIncrease` to 0 to disable increasing cardinality when updating pool.
    */
   function getUpdatedPool(
     address tokenA,
     address tokenB,
-    uint256 updateInterval,
-    uint8 cardinalityIncrease
+    uint256 secondsUpdateInterval,
+    uint8 cardinalityNextIncrease
   )
     public
     returns (
@@ -148,17 +148,17 @@ contract PriceFeed is IPriceFeed {
       uint160 sqrtPriceX96
     )
   {
-    // Shortcircuit update when `updateInterval` == 0
-    if (updateInterval == 0) return updatePool(tokenA, tokenB, cardinalityIncrease);
+    // Shortcircuit update when `secondsUpdateInterval` == 0
+    if (secondsUpdateInterval == 0) return updatePool(tokenA, tokenB, cardinalityNextIncrease);
 
     pool = getPool(tokenA, tokenB);
 
-    // Update pool if no pool is stored or `updateInterval` has passed since `lastUpdatedTimestamp`
+    // Update pool if no pool is stored or `secondsUpdateInterval` has passed since `lastUpdatedTimestamp`
     if (
       pool.poolAddress == address(0) ||
-      pool.lastUpdatedTimestamp + updateInterval <= block.timestamp
+      pool.lastUpdatedTimestamp + secondsUpdateInterval <= block.timestamp
     ) {
-      return updatePool(tokenA, tokenB, cardinalityIncrease);
+      return updatePool(tokenA, tokenB, cardinalityNextIncrease);
     }
   }
 
@@ -167,36 +167,36 @@ contract PriceFeed is IPriceFeed {
    * @param baseAmount Amount of baseToken to be converted
    * @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
    * @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
-   * @param secondsAgo Number of seconds in the past from which to calculate the time-weighted quote
-   * @param updateInterval Seconds after which a pool is considered stale and an update is triggered
-   * @param cardinalityIncrease The increase in cardinality to trigger in a pool if current value < MAX_CARDINALITY
+   * @param secondsTwapInterval Number of seconds in the past from which to calculate the time-weighted quote
+   * @param secondsUpdateInterval Seconds after which a pool is considered stale and an update is triggered
+   * @param cardinalityNextIncrease The increase in cardinality to trigger in a pool if current value < MAX_CARDINALITY
    * @return quoteAmount Equivalent amount of ERC20 token for baseAmount
    *
    * Note: If a pool does not exist or a valid quote is not returned execution will not revert and
    * `quoteAmount` will be 0.
-   * Note: Set updateInterval to 0 to always trigger an update, or to block.timestamp to only update if a pool
+   * Note: Set `secondsUpdateInterval` to 0 to always trigger an update, or to block.timestamp to only update if a pool
    * has not been stored yet.
-   * Note: Set `cardinalityIncrease` to 0 to disable increasing cardinality when updating pool.
+   * Note: Set `cardinalityNextIncrease` to 0 to disable increasing cardinality when updating pool.
    */
   function getQuoteAndUpdatePool(
     uint128 baseAmount,
     address baseToken,
     address quoteToken,
-    uint32 secondsAgo,
-    uint256 updateInterval,
-    uint8 cardinalityIncrease
+    uint32 secondsTwapInterval,
+    uint256 secondsUpdateInterval,
+    uint8 cardinalityNextIncrease
   ) public returns (uint256 quoteAmount) {
     (PoolData memory pool, int56[] memory tickCumulatives, uint160 sqrtPriceX96) = getUpdatedPool(
       baseToken,
       quoteToken,
-      updateInterval,
-      cardinalityIncrease
+      secondsUpdateInterval,
+      cardinalityNextIncrease
     );
 
     // If pool exists
     if (pool.poolAddress != address(0)) {
       // Get spot price
-      if (secondsAgo == 0) {
+      if (secondsTwapInterval == 0) {
         // If sqrtPriceX96 was not returned from `getUpdatedPool`
         if (sqrtPriceX96 == 0) {
           // Get sqrtPriceX96 from slot0
@@ -212,12 +212,14 @@ contract PriceFeed is IPriceFeed {
         if (tickCumulatives[0] != tickCumulatives[1]) {
           // Calculate arithmeticMeanTick from tickCumulatives
           int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
-          arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
+          arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsTwapInterval)));
           // Always round to negative infinity
-          if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsAgo)) != 0))
-            arithmeticMeanTick--;
+          if (
+            tickCumulativesDelta < 0 &&
+            (tickCumulativesDelta % int56(uint56(secondsTwapInterval)) != 0)
+          ) arithmeticMeanTick--;
         } else {
-          arithmeticMeanTick = _getArithmeticMeanTick(pool.poolAddress, secondsAgo);
+          arithmeticMeanTick = _getArithmeticMeanTick(pool.poolAddress, secondsTwapInterval);
         }
 
         quoteAmount = OracleLibrary.getQuoteAtTick(
@@ -234,7 +236,7 @@ contract PriceFeed is IPriceFeed {
    * @notice Updates stored pool with the one having the highest TWAL in the last 30 minutes.
    * @param tokenA Address of one of the ERC20 token contract in the pool
    * @param tokenB Address of the other ERC20 token contract in the pool
-   * @param cardinalityIncrease The amount of observation cardinality to increase when updating a pool if
+   * @param cardinalityNextIncrease The amount of observation cardinality to increase when updating a pool if
    * current value < MAX_CARDINALITY
    * @return highestLiquidityPool Pool with the highest harmonic mean liquidity
    * @return tickCumulatives Cumulative tick values as of 30 minutes from the current block timestamp
@@ -243,7 +245,7 @@ contract PriceFeed is IPriceFeed {
   function updatePool(
     address tokenA,
     address tokenB,
-    uint8 cardinalityIncrease
+    uint8 cardinalityNextIncrease
   )
     public
     returns (
@@ -259,7 +261,7 @@ contract PriceFeed is IPriceFeed {
     (highestLiquidityPool, tickCumulatives, sqrtPriceX96) = _getHighestLiquidityPool(
       token0,
       token1,
-      cardinalityIncrease
+      cardinalityNextIncrease
     );
 
     /// Update pool in storage with `highestLiquidityPool`
@@ -283,7 +285,7 @@ contract PriceFeed is IPriceFeed {
    * @notice Gets the pool with the highest harmonic liquidity.
    * @param token0 Address of the first ERC20 token contract in the pool
    * @param token1 Address of the second ERC20 token contract in the pool
-   * @param cardinalityIncrease The amount of observation cardinality to increase when updating a pool if
+   * @param cardinalityNextIncrease The amount of observation cardinality to increase when updating a pool if
    * current value < MAX_CARDINALITY
    * @return highestLiquidityPool Pool with the highest highest harmonic mean liquidity
    * @return tickCumulatives Cumulative tick values as of 30 minutes from the current block timestamp
@@ -292,7 +294,7 @@ contract PriceFeed is IPriceFeed {
   function _getHighestLiquidityPool(
     address token0,
     address token1,
-    uint8 cardinalityIncrease
+    uint8 cardinalityNextIncrease
   )
     private
     returns (
@@ -342,13 +344,13 @@ contract PriceFeed is IPriceFeed {
 
       // If a cardinality increase is wanted and current cardinalityNext < MAX_CARDINALITY
       if (
-        cardinalityIncrease != 0 &&
+        cardinalityNextIncrease != 0 &&
         highestLiquidityPool.lastUpdatedCardinalityNext < MAX_CARDINALITY
       ) {
         // Increase cardinality and update value in reference pool
         // Cannot overflow uint16 as MAX_CARDINALITY + type(uint8).max < uint(16).max
         unchecked {
-          highestLiquidityPool.lastUpdatedCardinalityNext += cardinalityIncrease;
+          highestLiquidityPool.lastUpdatedCardinalityNext += cardinalityNextIncrease;
           IUniswapV3Pool(highestLiquidityPool.poolAddress).increaseObservationCardinalityNext(
             highestLiquidityPool.lastUpdatedCardinalityNext
           );
@@ -360,23 +362,23 @@ contract PriceFeed is IPriceFeed {
   /**
    * @notice Same as `consult` in {OracleLibrary} but saves gas by not calculating `harmonicMeanLiquidity`.
    * @param pool Address of the pool that we want to observe
-   * @param secondsAgo Number of seconds in the past from which to calculate the time-weighted means
-   * @return arithmeticMeanTick The arithmetic mean tick from (block.timestamp - secondsAgo) to block.timestamp
+   * @param secondsTwapInterval Number of seconds in the past from which to calculate the time-weighted means
+   * @return arithmeticMeanTick The arithmetic mean tick from (block.timestamp - secondsTwapInterval) to block.timestamp
    *
    * @dev Silently handles errors in `uniswapV3Pool.observe` to prevent reverts.
    */
-  function _getArithmeticMeanTick(address pool, uint32 secondsAgo)
+  function _getArithmeticMeanTick(address pool, uint32 secondsTwapInterval)
     private
     view
     returns (int24 arithmeticMeanTick)
   {
-    uint32[] memory secondsAgos = new uint32[](2);
-    secondsAgos[0] = secondsAgo;
-    secondsAgos[1] = 0;
+    uint32[] memory secondsTwapIntervals = new uint32[](2);
+    secondsTwapIntervals[0] = secondsTwapInterval;
+    secondsTwapIntervals[1] = 0;
 
     // Call uniswapV3Pool.observe
     (bool success, bytes memory data) = pool.staticcall(
-      abi.encodeWithSelector(0x883bdbfd, secondsAgos)
+      abi.encodeWithSelector(0x883bdbfd, secondsTwapIntervals)
     );
 
     // If observe hasn't reverted
@@ -386,10 +388,11 @@ contract PriceFeed is IPriceFeed {
 
       int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
 
-      arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
+      arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsTwapInterval)));
       // Always round to negative infinity
-      if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsAgo)) != 0))
-        arithmeticMeanTick--;
+      if (
+        tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsTwapInterval)) != 0)
+      ) arithmeticMeanTick--;
     }
   }
 
@@ -397,7 +400,7 @@ contract PriceFeed is IPriceFeed {
    * @notice Same as `consult` in {OracleLibrary} but saves gas by not calculating `arithmeticMeanTick` and
    * defaulting to twap interval to `UPDATE_SECONDS_AGO`.
    * @param pool Address of the pool that we want to observe
-   * @return harmonicMeanLiquidity The harmonic mean liquidity from (block.timestamp - secondsAgo) to block.timestamp
+   * @return harmonicMeanLiquidity The harmonic mean liquidity from (block.timestamp - secondsTwapInterval) to block.timestamp
    * @return tickCumulatives Cumulative tick values as of 30 minutes from the current block timestamp
    *
    * @dev Silently handles errors in `uniswapV3Pool.observe` to prevent reverts.

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -26,14 +26,14 @@ contract PriceFeed is IPriceFeed {
   /// ======= Immutable Storage =======
   /// =================================
 
+  /// Current observation cardinality value under which a cardinality increase is triggered when updating pools
+  uint16 public constant MAX_CARDINALITY = 256;
   /// TWAP interval used when updating pools
   uint32 public constant UPDATE_INTERVAL = 30 minutes;
   /// UPDATE_INTERVAL multiplied by 2**160
   uint192 private constant UPDATE_INTERVAL_X160 = uint192(UPDATE_INTERVAL) << 160;
   /// UPDATE_INTERVAL formatted as uint32[]
   uint32[] private UPDATE_SECONDS_AGO = [UPDATE_INTERVAL, 0];
-  /// Current observation cardinality value under which a cardinality increase is triggered when updating pools
-  uint16 public MAX_CARDINALITY = 256;
   /// UniswapV3Pool fee tiers
   uint24[] public fees = [10000, 3000, 500, 100];
   /// Mapping of active fee tiers

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -33,9 +33,9 @@ contract PriceFeed is IPriceFeed {
   uint32[] private UPDATE_SECONDS_AGO = [UPDATE_INTERVAL, 0];
   /// UniswapV3Pool possible fee amounts
   uint24[] private FEES = [10000, 3000, 500, 100];
-  /// Max cardinality value when updating pools via `getUpdatedPool` or `getQuoteAndUpdatePool`
-  /// @dev Max useful cardinality for 30-min TWAPs, based on a max of 5 observation per minute.
-  uint16 public MAX_CARDINALITY = 150;
+  /// Value under which cardinality increase is triggered when updating pools via `getUpdatedPool`
+  /// or `getQuoteAndUpdatePool`
+  uint16 public MAX_CARDINALITY = 256;
   /// UniswapV3Factory contract address
   address public immutable uniswapV3Factory;
 

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -76,7 +76,6 @@ contract PriceFeed is IPriceFeed {
    * @param secondsAgo Number of seconds in the past from which to calculate the time-weighted quote
    * @return quoteAmount Equivalent amount of ERC20 token for baseAmount
    *
-   * Requirement: `secondsAgo` must be greater than 0.
    * Note: If a pool does not exist or a valid quote is not returned execution will not revert and
    * `quoteAmount` will be 0.
    */
@@ -149,7 +148,6 @@ contract PriceFeed is IPriceFeed {
    * @param updateInterval Seconds after which a pool is considered stale and an update is triggered
    * @return quoteAmount Equivalent amount of ERC20 token for baseAmount
    *
-   * Requirement: `secondsAgo` must be greater than 0.
    * Note: If a pool does not exist or a valid quote is not returned execution will not revert and
    * `quoteAmount` will be 0.
    * Note: Set updateInterval to 0 to always trigger an update, or to block.timestamp to only update if a pool

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -336,20 +336,21 @@ contract PriceFeed is IPriceFeed {
     // If there is a pool to update
     if (highestLiquidityPool.poolAddress != address(0)) {
       // Update observation cardinality of `highestLiquidityPool`
-      (sqrtPriceX96, , , highestLiquidityPool.lastUpdatedCardinality, , , ) = IUniswapV3Pool(
+      (sqrtPriceX96, , , , highestLiquidityPool.lastUpdatedCardinalityNext, , ) = IUniswapV3Pool(
         highestLiquidityPool.poolAddress
       ).slot0();
 
-      // If a cardinality increase is wanted and current cardinality < MAX_CARDINALITY
+      // If a cardinality increase is wanted and current cardinalityNext < MAX_CARDINALITY
       if (
-        cardinalityIncrease != 0 && highestLiquidityPool.lastUpdatedCardinality < MAX_CARDINALITY
+        cardinalityIncrease != 0 &&
+        highestLiquidityPool.lastUpdatedCardinalityNext < MAX_CARDINALITY
       ) {
         // Increase cardinality and update value in reference pool
         // Cannot overflow uint16 as MAX_CARDINALITY + type(uint8).max < uint(16).max
         unchecked {
-          highestLiquidityPool.lastUpdatedCardinality += cardinalityIncrease;
+          highestLiquidityPool.lastUpdatedCardinalityNext += cardinalityIncrease;
           IUniswapV3Pool(highestLiquidityPool.poolAddress).increaseObservationCardinalityNext(
-            highestLiquidityPool.lastUpdatedCardinality
+            highestLiquidityPool.lastUpdatedCardinalityNext
           );
         }
       }

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -30,7 +30,13 @@ interface IPriceFeed {
     address tokenB,
     uint256 updateInterval,
     uint8 cardinalityIncrease
-  ) external returns (PoolData memory pool);
+  )
+    external
+    returns (
+      PoolData memory pool,
+      int56[] memory tickCumulatives,
+      uint160 sqrtPriceX96
+    );
 
   function getQuoteAndUpdatePool(
     uint128 baseAmount,

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -12,7 +12,8 @@ interface IPriceFeed {
     returns (
       address poolAddress,
       uint24 fee,
-      uint48 lastUpdatedTimestamp
+      uint48 lastUpdatedTimestamp,
+      uint16 lastUpdatedCardinality
     );
 
   function getPool(address tokenA, address tokenB) external view returns (PoolData memory pool);
@@ -27,7 +28,8 @@ interface IPriceFeed {
   function getUpdatedPool(
     address tokenA,
     address tokenB,
-    uint256 updateInterval
+    uint256 updateInterval,
+    uint8 cardinalityIncrease
   ) external returns (PoolData memory pool);
 
   function getQuoteAndUpdatePool(
@@ -35,10 +37,19 @@ interface IPriceFeed {
     address baseToken,
     address quoteToken,
     uint32 secondsAgo,
-    uint256 updateInterval
+    uint256 updateInterval,
+    uint8 cardinalityIncrease
   ) external returns (uint256 quoteAmount);
 
-  function updatePool(address tokenA, address tokenB)
+  function updatePool(
+    address tokenA,
+    address tokenB,
+    uint8 cardinalityIncrease
+  )
     external
-    returns (PoolData memory highestLiquidityPool, int56[] memory tickCumulatives);
+    returns (
+      PoolData memory highestLiquidityPool,
+      int56[] memory tickCumulatives,
+      uint160 sqrtPriceX96
+    );
 }

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -26,14 +26,14 @@ interface IPriceFeed {
     uint128 baseAmount,
     address baseToken,
     address quoteToken,
-    uint32 secondsAgo
+    uint32 secondsTwapInterval
   ) external view returns (uint256 quoteAmount);
 
   function getUpdatedPool(
     address tokenA,
     address tokenB,
-    uint256 updateInterval,
-    uint8 cardinalityIncrease
+    uint256 secondsUpdateInterval,
+    uint8 cardinalityNextIncrease
   )
     external
     returns (
@@ -46,15 +46,15 @@ interface IPriceFeed {
     uint128 baseAmount,
     address baseToken,
     address quoteToken,
-    uint32 secondsAgo,
-    uint256 updateInterval,
-    uint8 cardinalityIncrease
+    uint32 secondsTwapInterval,
+    uint256 secondsUpdateInterval,
+    uint8 cardinalityNextIncrease
   ) external returns (uint256 quoteAmount);
 
   function updatePool(
     address tokenA,
     address tokenB,
-    uint8 cardinalityIncrease
+    uint8 cardinalityNextIncrease
   )
     external
     returns (

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -6,6 +6,8 @@ import "../structs/PoolData.sol";
 interface IPriceFeed {
   function uniswapV3Factory() external view returns (address uniswapV3Factory);
 
+  function fees(uint256 index) external view returns (uint24 fee);
+
   function pools(address token0, address token1)
     external
     view
@@ -58,4 +60,6 @@ interface IPriceFeed {
       int56[] memory tickCumulatives,
       uint160 sqrtPriceX96
     );
+
+  function addFee(uint24 fee) external;
 }

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -6,6 +6,8 @@ import "../structs/PoolData.sol";
 interface IPriceFeed {
   function uniswapV3Factory() external view returns (address uniswapV3Factory);
 
+  function activeFees(uint24 index) external view returns (bool);
+
   function fees(uint256 index) external view returns (uint24 fee);
 
   function pools(address token0, address token1)

--- a/contracts/structs/PoolData.sol
+++ b/contracts/structs/PoolData.sol
@@ -5,5 +5,5 @@ struct PoolData {
   address poolAddress;
   uint24 fee;
   uint48 lastUpdatedTimestamp;
-  uint16 lastUpdatedCardinality;
+  uint16 lastUpdatedCardinalityNext;
 }

--- a/contracts/structs/PoolData.sol
+++ b/contracts/structs/PoolData.sol
@@ -5,4 +5,5 @@ struct PoolData {
   address poolAddress;
   uint24 fee;
   uint48 lastUpdatedTimestamp;
+  uint16 lastUpdatedCardinality;
 }

--- a/test/mocks/MockPool.sol
+++ b/test/mocks/MockPool.sol
@@ -4,6 +4,25 @@ pragma solidity >=0.8.0;
 import {ERC20} from "solmate/tokens/ERC20.sol";
 
 contract MockPool {
+  struct Slot0 {
+    // the current price
+    uint160 sqrtPriceX96;
+    // the current tick
+    int24 tick;
+    // the most-recently updated index of the observations array
+    uint16 observationIndex;
+    // the current maximum number of observations that are being stored
+    uint16 observationCardinality;
+    // the next maximum number of observations to store, triggered in observations.write
+    uint16 observationCardinalityNext;
+    // the current protocol fee as a percentage of the swap fee taken on withdrawal
+    // represented as an integer denominator (1/x)%
+    uint8 feeProtocol;
+    // whether the pool is locked
+    bool unlocked;
+  }
+  Slot0 public slot0;
+
   function observe(uint32[] calldata)
     external
     pure
@@ -18,5 +37,19 @@ contract MockPool {
     b[1] = 4394094107204170683664807220887586463231635652;
 
     return (a, b);
+  }
+
+  function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external {
+    // uint16 observationCardinalityNextOld = slot0.observationCardinalityNext; // for the event
+    // uint16 observationCardinalityNextNew = observations.grow(
+    //   observationCardinalityNextOld,
+    //   observationCardinalityNext
+    // );
+    slot0.observationCardinalityNext = observationCardinalityNext;
+    // if (observationCardinalityNextOld != observationCardinalityNextNew)
+    //   emit IncreaseObservationCardinalityNext(
+    //     observationCardinalityNextOld,
+    //     observationCardinalityNextNew
+    //   );
   }
 }

--- a/test/test.t.sol
+++ b/test/test.t.sol
@@ -46,6 +46,10 @@ contract BaseTest is DSTestPlus {
   }
 
   function testUpdatePool() public {
-    priceFeed.updatePool(address(token1), address(token2));
+    priceFeed.updatePool(address(token1), address(token2), 0);
+  }
+
+  function testGetUpdatedPool() public {
+    priceFeed.getUpdatedPool(address(token1), address(token2), 10, 10);
   }
 }


### PR DESCRIPTION
This PR introduces multiple updates over core logic of the price feed. Closes #7 #8.

## Cardinality
- Added `lastUpdatedCardinality` in `PoolData` struct and `MAX_CARDINALITY`
- Added logic to increase observationCardinalityNext when updating pools, according to `cardinalityNextIncrease` param specified by the caller

## Spot price
- Added possibility to set `secondsTwapInterval` to 0, calculating quotes from the spot price of a pool

## Fees
- Introduced `addFee` to permissionlessly introduce new fee tiers when supported by Uniswap, and use them during `updatePool`

## Other
- Refactored code and renamed variables
- Updated `IPriceFeed` interface
- Updated readme

---

### Notes
- `MAX_CARDINALITY` value has been hardcoded to 256.